### PR TITLE
[buteo-sync-plugin-carddav] Resolve relative redirects before validation

### DIFF
--- a/src/carddav.cpp
+++ b/src/carddav.cpp
@@ -601,6 +601,8 @@ void CardDav::userInformationResponse()
     QUrl redir = reply->attribute(QNetworkRequest::RedirectionTargetAttribute).toUrl();
     if (!redir.isEmpty()) {
         QUrl orig = reply->url();
+        // In case of a relative redirect, resolve it, so the code below does not have to take relative redirects into account
+        redir = orig.resolved(redir);
         qCDebug(lcCardDav) << Q_FUNC_INFO << "server requested redirect from:" << orig.toString() << "to:" << redir.toString();
         const bool hostChanged = orig.host() != redir.host();
         const bool pathChanged = orig.path() != redir.path();
@@ -619,19 +621,7 @@ void CardDav::userInformationResponse()
         } else {
             // redirect as required, and change our server URL to point to the redirect URL.
             qCDebug(lcCardDav) << Q_FUNC_INFO << "redirecting from:" << orig.toString() << "to:" << redir.toString();
-            QString redirPort;
-            if (redir.port() != -1) {
-                // the redirect was a url, and includes a port.  use it.
-                redirPort = QStringLiteral(":%1").arg(redir.port());
-            } else if (redir.host().isEmpty() && orig.port() != -1) {
-                // the redirect was a path, not a url.  use the original port.
-                redirPort = QStringLiteral(":%1").arg(orig.port());
-            }
-            m_serverUrl = QStringLiteral("%1://%2%3%4")
-                    .arg(redir.scheme().isEmpty() ? orig.scheme() : redir.scheme())
-                    .arg(redir.host().isEmpty() ? orig.host() : redir.host())
-                    .arg(redirPort)
-                    .arg(redir.path());
+            m_serverUrl = redir.url();
             m_discoveryStage = CardDav::DiscoveryRedirected;
             fetchUserInformation();
         }


### PR DESCRIPTION
The validation code for redirects always assumes the redirect is an
absolute URL. When the redirect is not an absolute URL, the hostname
of the unresolved redirect URL is empty, while the hostname of the
original URL isn't.  Hence, hostChanged will always be true and the
validation code will throw an error, while it shouldn't.

This commit fixes the following issue reported on the Sailfish Community
Forums: https://forum.sailfishos.org/t/11033