### PR TITLE
move invoked methods to SLOTS

### DIFF
--- a/src/syncer_p.h
+++ b/src/syncer_p.h
@@ -86,13 +86,13 @@ protected:
             const QList<QContact> &addedContacts,
             const QList<QContact> &modifiedContacts,
             const QList<QContact> &deletedContacts);
-    void syncFinishedSuccessfully();
-    void syncFinishedWithError();
 
 private Q_SLOTS:
     void sync(const QString &serverUrl, const QString &addressbookPath, const QString &username, const QString &password, const QString &accessToken, bool ignoreSslErrors);
     void signInError();
     void cardDavError(int errorCode = 0);
+    void syncFinishedSuccessfully();
+    void syncFinishedWithError();
 
 private:
     friend class CardDav;


### PR DESCRIPTION
On authentication failure, carddav plugin doesn't notify syncfw since it failed at calling syncFinishedWithError():
`msyncd[5566]: QMetaObject::invokeMethod: No such method Syncer::syncFinishedWithError()`

Moving method to a SLOT declaration fix it