### PR TITLE
emit syncfailed on cardavError

### DIFF
--- a/src/syncer.cpp
+++ b/src/syncer.cpp
@@ -359,7 +359,7 @@ void Syncer::cardDavError(int errorCode)
     if (errorCode == HTTP_UNAUTHORIZED_ACCESS) {
         m_auth->setCredentialsNeedUpdate(m_accountId);
     }
-    QMetaObject::invokeMethod(this, "syncFinishedWithError", Qt::QueuedConnection);
+    QMetaObject::invokeMethod(this, "syncFailed", Qt::QueuedConnection);
 }
 
 void Syncer::purgeAccount(int accountId)


### PR DESCRIPTION
On authentication failure, carddav plugin doesn't notify syncfw since it failed at calling syncFinishedWithError():
msyncd[5566]: QMetaObject::invokeMethod: No such method Syncer::syncFinishedWithError()

Instead invoke Signal syncFailed


replace #6 